### PR TITLE
Get actions for orgs

### DIFF
--- a/FullCircle/FullCircle/Controllers/ActionDetailViewController.swift
+++ b/FullCircle/FullCircle/Controllers/ActionDetailViewController.swift
@@ -25,8 +25,8 @@ class ActionDetailViewController: UIViewController {
     
     private lazy var orgLogoView: UIImageView = {
         let imageView = UIImageView()
-        // TODO: Refactor to obtain org info from Firebase
-//        imageView.image = UIImage(named: self.action.organizationID.logoString)
+        // TODO: Get image from Firebase Storage
+        //        imageView.image = UIImage(named: self.action.organizationID.logoString)
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
@@ -34,8 +34,7 @@ class ActionDetailViewController: UIViewController {
     private lazy var orgNameLabel: FCHeaderLabel = {
         let label = FCHeaderLabel()
         label.textAlignment = .center
-        // TODO: Refactor to obtain org info from Firebase
-//        label.text = action.organizationID.name
+        label.text = action.organizationName
         return label
     }()
     

--- a/FullCircle/FullCircle/Controllers/ActionListViewController/ActionListViewController.swift
+++ b/FullCircle/FullCircle/Controllers/ActionListViewController/ActionListViewController.swift
@@ -80,7 +80,7 @@ class ActionListViewController: UIViewController {
     }()
     
     //MARK: - Internal Properties
-    private var actions = [Action]() {
+    internal var actions = [Action]() {
         didSet {
             actionListTableView.reloadData()
         }

--- a/FullCircle/FullCircle/Controllers/ActionListViewController/ActionListViewController.swift
+++ b/FullCircle/FullCircle/Controllers/ActionListViewController/ActionListViewController.swift
@@ -80,7 +80,7 @@ class ActionListViewController: UIViewController {
     }()
     
     //MARK: - Internal Properties
-    var actions = [Action]() {
+    private var actions = [Action]() {
         didSet {
             actionListTableView.reloadData()
         }
@@ -100,7 +100,7 @@ class ActionListViewController: UIViewController {
         getActions()
     }
     
-    //MARK: Private Methods
+    //MARK: - Private Methods
     //MARK: TODO - Differentiate Firestore requests based on app source
     /* This view controller is used for lists of ALL actions (by all orgs) and actions for specific org. It will be important to differentiate these sources of data in the future when there is more pre-seeded/live data in Firestore */
     private func getActions() {

--- a/FullCircle/FullCircle/Controllers/OrgDetailViewController/OrgDetailViewController.swift
+++ b/FullCircle/FullCircle/Controllers/OrgDetailViewController/OrgDetailViewController.swift
@@ -53,8 +53,8 @@ extension OrgDetailViewController {
         var couplers = [BaseCellCoupler]()
         
         //Logo
-        // TODO: update image from FB
-//        let orgLogo = OrgDetailImageCellData(image: organization.imageURL)
+        // TODO: Get image from Firebase Storage
+        //        let orgLogo = OrgDetailImageCellData(image: organization.imageURL)
 //        let orgLogoCell = CellCoupler(OrgDetailImageCell.self, orgLogo)
 //        couplers.append(orgLogoCell)
         

--- a/FullCircle/FullCircle/Controllers/OrgListViewController/OrgListViewController+TableView.swift
+++ b/FullCircle/FullCircle/Controllers/OrgListViewController/OrgListViewController+TableView.swift
@@ -22,8 +22,8 @@ extension OrgListViewController: UITableViewDataSource {
         \(organization.organizationType)
         \(organization.address)
         """
-        // TODO: update image from FB
-//        cell.orgLogoImageView.image = UIImage(named: organization.imageURL)
+        // TODO: Get image from Firebase Storage
+        //        cell.orgLogoImageView.image = UIImage(named: organization.imageURL)
         
         return cell
     }

--- a/FullCircle/FullCircle/Controllers/ProfileViewController/ProfileViewController+TableView.swift
+++ b/FullCircle/FullCircle/Controllers/ProfileViewController/ProfileViewController+TableView.swift
@@ -35,9 +35,10 @@ extension ProfileViewController: UITableViewDataSource {
             
             cell.actionNameLabel.text = action.name
             
-            // TODO: Refactor to obtain org info from Firebase
-//            cell.orgNameLabel.text = action.organizationID.name
-//            cell.actionTypeImageView.image = UIImage(named: action.organizationID.logoString)!
+
+            cell.orgNameLabel.text = action.organizationName
+            // TODO: Get image from Firebase Storage
+            // cell.actionTypeImageView.image = UIImage(named: action.organizationID.logoString)!
 
             
             

--- a/FullCircle/FullCircle/FirestoreService.swift
+++ b/FullCircle/FullCircle/FirestoreService.swift
@@ -39,7 +39,7 @@ class FirestoreService {
         }
     }
     
-    //MARK: Actions. TODO: Add getAll(forOrganization:) and getAll(forUser:)
+    //MARK: Actions. TODO: getAll(forUser:)
     func getAllActions(completion: @escaping (Result<[Action], Error>) -> ()) {
         db.collection(ModelTypes.action.rawValue).getDocuments { (snapshot, error) in
             if let error = error {
@@ -55,5 +55,19 @@ class FirestoreService {
         }
     }
     
+    func getOrganizationActions(id: String, with completion: @escaping (Result<[Action], Error>) -> ()) {
+        db.collection(ModelTypes.action.rawValue).whereField("organizationID", isEqualTo: id).getDocuments { (snapshot, error) in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                let actions = snapshot?.documents.compactMap({ (snapshot) -> Action? in
+                    let actionID = snapshot.documentID
+                    let action = Action(from: snapshot.data(), id: actionID)
+                    return action
+                })
+                completion(.success(actions ?? []))
+            }
+        }
+    }
     
 }

--- a/FullCircle/FullCircle/Models/Action/Action.swift
+++ b/FullCircle/FullCircle/Models/Action/Action.swift
@@ -13,6 +13,7 @@ struct Action {
     let name: String
     let description: String
     let organizationID: String
+    let organizationName: String
     let actionURL: String
     let imageURL: String
     let engagementLevel: EngagementLevel
@@ -23,6 +24,7 @@ struct Action {
         guard let name = dict["name"] as? String,
             let description = dict["description"] as? String,
             let organizationID = dict["organizationID"] as? String,
+            let organizationName = dict["organizationName"] as? String,
             let imageURL = dict["imageURL"] as? String,
             let actionURL = dict["actionURL"] as? String,
             let level = dict["engagementLevel"] as? String,
@@ -35,6 +37,7 @@ struct Action {
         self.name = name
         self.description = description
         self.organizationID = organizationID
+        self.organizationName = organizationName
         self.imageURL = imageURL
         self.actionURL = actionURL
         self.engagementLevel = engagementLevel

--- a/FullCircle/FullCircle/Models/Action/Action.swift
+++ b/FullCircle/FullCircle/Models/Action/Action.swift
@@ -41,18 +41,6 @@ struct Action {
         self.actionType = actionType
         self.actionMeta = actionMeta
     }
-    
-    init(id: String ,name: String, description: String, organizationID: String, imageURL: String, iconString: String, engagementLevel: EngagementLevel, actionType: ActionType, actionMeta: [String : Any]) {
-        self.id = "action-\(UUID().description)"
-        self.name = name
-        self.description = description
-        self.organizationID = organizationID
-        self.actionURL = imageURL
-        self.imageURL = iconString
-        self.engagementLevel = engagementLevel
-        self.actionType = actionType
-        self.actionMeta = actionMeta
-    }
 
     enum EngagementLevel: String {
         case easy

--- a/FullCircle/FullCircle/Views/TableViewCells/ActionListViewController+TableView.swift
+++ b/FullCircle/FullCircle/Views/TableViewCells/ActionListViewController+TableView.swift
@@ -18,10 +18,9 @@ extension ActionListViewController: UITableViewDataSource {
         let action = actions[indexPath.row]
         
         cell.actionNameLabel.text = action.name
-        
-        // TODO: Refactor to obtain org info from Firebase
-//        cell.orgNameLabel.text = action.organizationID.name
-//        cell.actionTypeImageView.image = UIImage(named: action.organizationID.logoString)!
+        cell.orgNameLabel.text = action.organizationName
+        // TODO: Get image from Firebase Storage
+        //        cell.actionTypeImageView.image = UIImage(named: action.organizationID.logoString)!
         
         
         


### PR DESCRIPTION
Quick PR to make organization info call available. Note I added a new property to actions so that they have the name of the organization that created them, and updated UI based on this new property.

Held off on integrating the call into UI because CellDataCoupler pod is still in the process of being removed.